### PR TITLE
Fix zoom on hover not working with React 18 💞

### DIFF
--- a/.changeset/six-comics-provide.md
+++ b/.changeset/six-comics-provide.md
@@ -1,0 +1,5 @@
+---
+"@zoom-image/core": patch
+---
+
+Fix zoom on hover not working with React 18 💞

--- a/packages/core/src/createZoomImageHover.ts
+++ b/packages/core/src/createZoomImageHover.ts
@@ -1,7 +1,7 @@
-import { imageCache } from "./store"
 import { createStore } from "@namnode/store"
+import { imageCache } from "./store"
 import { ZoomedImgStatus } from "./types"
-import { enableScroll, disableScroll, clamp, getSourceImage } from "./utils"
+import { clamp, disableScroll, enableScroll, getSourceImage } from "./utils"
 
 export type ZoomImageHoverOptions = {
   customZoom?: { width: number; height: number }
@@ -188,14 +188,14 @@ export function createZoomImageHover(container: HTMLElement, options: ZoomImageH
   return {
     cleanup: () => {
       controller.abort()
-      container.removeChild(zoomLens)
+      container.contains(zoomLens) && container.removeChild(zoomLens)
 
-      if (finalOptions.zoomTarget) {
+      if (finalOptions.zoomTarget && finalOptions.zoomTarget.contains(zoomedImgWrapper)) {
         finalOptions.zoomTarget.removeChild(zoomedImgWrapper)
         return
       }
 
-      container.removeChild(zoomedImgWrapper)
+      container.contains(zoomedImgWrapper) && container.removeChild(zoomedImgWrapper)
     },
     subscribe: store.subscribe,
     getState: store.getState,


### PR DESCRIPTION
Since React's useEffect got called twice during development mode. This causes some unexpected behaviour during development mode. This PR fixes exactly that by carefully detecting whether DOM is mutated correctly by React before making further execution :)