### PR TITLE
implement more intuitive zoom gesture behaviour

### DIFF
--- a/.changeset/cool-clouds-shout.md
+++ b/.changeset/cool-clouds-shout.md
@@ -1,0 +1,5 @@
+---
+"@zoom-image/core": patch
+---
+
+Make pinch zooming behaviour more intuitive

--- a/packages/core/src/createZoomImageWheel.ts
+++ b/packages/core/src/createZoomImageWheel.ts
@@ -324,7 +324,6 @@ export function createZoomImageWheel(container: HTMLElement, options: ZoomImageW
 
   function _handleTouchMove(event: TouchEvent) {
     event.preventDefault()
-    console.log(event.touches.length)
     if (event.touches.length === 2) {
       const currentTwoPositions = [...event.touches].map((t) => ({ x: t.clientX, y: t.clientY })) as [
         PointerPosition,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -56,6 +56,31 @@ export function getPointersCenter(first: PointerPosition, second: PointerPositio
   }
 }
 
+// Given the previous and current positions of two touch inputs, compute the zoom
+// factor and the origin of the zoom gesture.
+export function computeZoomGesture(prev: [PointerPosition, PointerPosition], curr: [PointerPosition, PointerPosition]) {
+  const prevCenter = getPointersCenter(prev[0], prev[1])
+  const currCenter = getPointersCenter(curr[0], curr[1])
+  const centerDist = { x: currCenter.x - prevCenter.x, y: currCenter.y - prevCenter.y }
+
+  const prevDistance = Math.hypot(prev[0].x - prev[1].x, prev[0].y - prev[1].y)
+  const currDistance = Math.hypot(curr[0].x - curr[1].x, curr[0].y - curr[1].y)
+  const scale = currDistance / prevDistance
+
+  // avoid division by zero
+  const eps = 0.00001
+
+  return {
+    scale,
+    center: {
+      // We shift the zoom center away such that the translation part of the gesture
+      // is also captured by the zoom operation.
+      x: prevCenter.x + centerDist.x / (1 - scale + eps),
+      y: prevCenter.y + centerDist.y / (1 - scale + eps),
+    },
+  }
+}
+
 export function makeMaybeCallFunction<T>(predicateFn: () => boolean, fn: (arg: T) => void) {
   return (arg: T) => {
     if (predicateFn()) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -65,18 +65,21 @@ export function computeZoomGesture(prev: [PointerPosition, PointerPosition], cur
 
   const prevDistance = Math.hypot(prev[0].x - prev[1].x, prev[0].y - prev[1].y)
   const currDistance = Math.hypot(curr[0].x - curr[1].x, curr[0].y - curr[1].y)
-  const scale = currDistance / prevDistance
+  let scale = currDistance / prevDistance
 
   // avoid division by zero
   const eps = 0.00001
+  if (Math.abs(scale - 1) < eps) {
+    scale = 1 + eps
+  }
 
   return {
     scale,
     center: {
       // We shift the zoom center away such that the translation part of the gesture
       // is also captured by the zoom operation.
-      x: prevCenter.x + centerDist.x / (1 - scale + eps),
-      y: prevCenter.y + centerDist.y / (1 - scale + eps),
+      x: prevCenter.x + centerDist.x / (1 - scale),
+      y: prevCenter.y + centerDist.y / (1 - scale),
     },
   }
 }


### PR DESCRIPTION
fixes #283

This works nicely in chrome on android, here's a comparison between the old behaviour on the left and the version of this PR on the right:

[chrome-old-new.webm](https://github.com/willnguyen1312/zoom-image/assets/18399125/b462ae57-c8a2-49d9-8401-4264c92df8e3)

Note how the two touch locations now remain pinned to the underlying image locations.

Unfortunately this doesn't work entirely yet, since the behaviour in Firefox on android is now more annoying (this is fixed in a later commit, check the [update below](https://github.com/willnguyen1312/zoom-image/pull/284#issuecomment-2102745605)):

[ff-new.webm](https://github.com/willnguyen1312/zoom-image/assets/18399125/9ecde8c5-d919-4268-b971-59c0ebc613a0)

The problem here lies with the onpointermove events. When both pointers are moving simultaneously, it can happen that firefox only sends updates for one of the pointers for a while, which means that when the other pointer finally does get an update, it arrives as a large instantaneous jump. Chrome apparently sends a more even rate of updates. Note that I've only tested this on my android phone, I don't know what the behaviour on other browsers on other operating systems would be, but I could imagine a similar problem arising for more setups than just firefox on android.

I saw that the manuelstofer/pinch-zoom library [listens to `touchmove` events](https://github.com/manuelstofer/pinchzoom/blob/dead159eb6fea063d8b7182406a4beb51383d303/src/pinch-zoom.js#L935) rather than `pointermove` events, and when testing that library the zoom appeared smooth in all browsers. I'm guessing that the update rate is more consistent for touch events.

Since I believe that the experience on firefox is now worse than it was before this PR, I'm only sending the PR as a draft to see what you think about this and to then possibly later switch to touch events depending on what comes out of our discussion.

Feel free to ask if anything is unclear!