### PR TITLE
Prevent jump when zooming out with double tap

### DIFF
--- a/.changeset/kind-impalas-smoke.md
+++ b/.changeset/kind-impalas-smoke.md
@@ -1,0 +1,5 @@
+---
+"@zoom-image/core": patch
+---
+
+Prevent jump when zooming out with double tap


### PR DESCRIPTION
Hi, I'm back with another PR :)

This time I took a look at the zooming animation that appears when double-tapping. Specifically, when zooming out, the previous implementation sometimes had a visual jump at the start of the zoom-out animation. I recorded an example in this video:

[zoomout-old.webm](https://github.com/willnguyen1312/zoom-image/assets/18399125/77d6f136-3fcc-4537-9ef6-909972322c4f)

The problem was that the `x` and `y` variables were updated on every touch, meaning that when zooming out, the zoom location would first jump to the coordinate where the touch happened. My first instinct to fix this was to just only update the coordinates when zooming in, and leave them at the same value when zooming out. Unfortunately this doesn't work, since the start of the zoom-out animation will be wherever the zoom-in animation ended, and thus will still jump if the user has panned around in the meantime.

To fix this, I had to make some significant changes to the `animateZoom` function. This function now starts by determining a start and end location for the zoom animation, and then only passing an inner function to `requestAnimationFrame` instead of re-running the calculations on every frame. The start of the zoom-out animation can now be computed from the current state.

The new behaviour looks like this:

[zoomout-new.webm](https://github.com/willnguyen1312/zoom-image/assets/18399125/1bdc6e3e-e304-473b-99eb-1c2095a10a56)

I believe that these changes also make the `animateZoom` function more readable, but of course I'm biased since this time I'm the one who wrote it 😅 so I'll let you be the judge of that